### PR TITLE
Require a serie for arch specific builds

### DIFF
--- a/lp-build-snap
+++ b/lp-build-snap
@@ -15,7 +15,7 @@ workdir = home+"/snap-builds"
 parser = argparse.ArgumentParser(description='Trigger a Snap build in Launchpad. If no series or arch argument is specific it will default to the serie defined by the snapcraft.yaml and build on the available architectures.')
 parser.add_argument("--lpname", dest="lpname", default=os.getenv("USER"), help="Launchpad user or team to build from (default: %s)"%os.getenv("USER"))
 parser.add_argument("--arch", dest="arch", default=None, help="Build architecture to target")
-parser.add_argument("--series", dest="series", default="bionic", help="Ubuntu release to build against (default: bionic)")
+parser.add_argument("--series", dest="series", help="Ubuntu release to build against, required for an arch specific build")
 parser.add_argument("--core-channel", dest="core", default=None, help="Channel to find core (default: None)")
 parser.add_argument("--snapcraft-channel", dest="snapcraft", default=None, help="Channel to find snapcraft (default: None)")
 parser.add_argument("snap_name", help="Name of the Snap package being built")
@@ -27,6 +27,10 @@ people_name = args.lpname
 snap_name = args.snap_name
 buildarch = args.arch
 series = args.series
+if buildarch:
+    if not series:
+        print("Building on a specific arch requires to also specify the serie")
+        exit(1)
 core = args.core
 snapcraft = args.snapcraft
 
@@ -68,6 +72,7 @@ if buildarch:
     release = ubuntu.getSeries(name_or_version=series)
     arch = release.getDistroArchSeries(archtag=buildarch)
 
+exit(1)
 # trigger build
 if core or snapcraft:
     if not core:


### PR DESCRIPTION
In this case the build defaults to use bionic but it's often not what you want and confusing